### PR TITLE
docs(triplestore): introduced graphdb as default option

### DIFF
--- a/docs/deployment/local-deployment.rst
+++ b/docs/deployment/local-deployment.rst
@@ -230,7 +230,8 @@ Alternatively, these steps can be automated with the following addition to the `
                   # move graphdb job to foreground
                   fg
             healthcheck:
-                test: curl http://localhost:7200/rest/repositories/fdp
+                # https://graphdb.ontotext.com/documentation/10.7/database-health-checks.html
+                test: curl --fail-with-body http://localhost:7200/repositories/fdp/health || exit 1
                 interval: 5s
 
 The ``repo.json`` file contains the configuration for the newly created GraphDB repository. The following is a bare minimum example.

--- a/docs/deployment/local-deployment.rst
+++ b/docs/deployment/local-deployment.rst
@@ -9,9 +9,8 @@ Here is an example of the simplest `Docker Compose <https://docs.docker.com/comp
 .. code-block:: yaml
    :substitutions:
 
-    # docker-compose.yml
+    # compose.yml
 
-    version: '3'
     services:
 
         fdp:
@@ -28,7 +27,7 @@ Here is an example of the simplest `Docker Compose <https://docs.docker.com/comp
             image: mongo:4.0.12
 
 
-Then you can run it using ``docker-compose up -d``. It might take a while to start. You can run ``docker-compose logs -f`` to follow the output log. Once you see a message, that the application started, the FAIR Data Point should be working, and you can open http://localhost.
+Then you can run it using ``docker compose up -d``. It might take a while to start. You can run ``docker compose logs -f`` to follow the output log. Once you see a message, that the application started, the FAIR Data Point should be working, and you can open http://localhost.
 
 
 There are two default user accounts. See the :ref:`Users and Roles <users-and-roles>` section to read more about users and roles. The default accounts are
@@ -63,9 +62,8 @@ Then, we need to mount the application config into the FDP container and update 
 .. code-block:: yaml
    :substitutions:
 
-    # docker-compose.yml
+    # compose.yml
 
-    version: '3'
     services:
 
         fdp:
@@ -97,14 +95,13 @@ We use MongoDB to store information about user accounts and access permissions. 
 
 We can also expose port ``27017`` so we can access MongoDB from our local computer using a client application like `Robo 3T <https://robomongo.org>`__.
 
-Here is the updated docker-compose file:
+Here is the updated docker compose file:
 
 .. code-block:: yaml
    :substitutions:
 
-    # docker-compose.yml
+    # compose.yml
 
-    version: '3'
     services:
 
         fdp:
@@ -147,14 +144,13 @@ If we don't have it already, we need to create a new file ``application.yml``. W
             url: http://graphdb:7200
             repository: fdp
 
-We now need to update our ``docker-compose.yml`` file, we add a new volume for the ``fdp`` and add ``graphdb`` service. We can also expose port ``7200`` for GraphDB so we can access its user interface.
+We now need to update our ``compose.yml`` file, we add a new volume for the ``fdp`` and add ``graphdb`` service. We can also expose port ``7200`` for GraphDB so we can access its user interface.
 
 .. code-block:: yaml
    :substitutions:
 
-    # docker-compose.yml
+    # compose.yml
 
-    version: '3'
     services:
 
         fdp:
@@ -176,12 +172,12 @@ We now need to update our ``docker-compose.yml`` file, we add a new volume for t
             volumes:
                 - ./mongo/data:/data/db
 
-      graphdb:
-        image: ontotext/graphdb:10.7.6
-        ports:
-          - 7200:7200
-        volumes:
-          - ./graphdb:/opt/graphdb/home
+        graphdb:
+            image: ontotext/graphdb:10.7.6
+            ports:
+                - 7200:7200
+            volumes:
+                - ./graphdb:/opt/graphdb/home
 
 GraphDB needs to have a repository set up before the FDP can interact with it. This can be done manually through the user interface, following these steps:
 

--- a/docs/deployment/production-deployment.rst
+++ b/docs/deployment/production-deployment.rst
@@ -55,7 +55,7 @@ Then, we need to configure the FDP server.
     server {
         listen 443 ssl;
 
-        # Generated certificates using certbot, we will mount these in docker-compose.yml
+        # Generated certificates using certbot, we will mount these in compose.yml
         ssl_certificate /etc/letsencrypt/live/fdp.example.com/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/fdp.example.com/privkey.pem;
 
@@ -84,14 +84,13 @@ Finally, we need to create a soft link from sites-enabled to sites-available for
 
     $ cd nginx/sites-enabled && ln -s ../sites-available/fdp.conf
 
-We have certificates generated and configuration for proxy ready. Now we need to add the proxy to our ``docker-compose.yml`` file so we can run the whole FDP behind the proxy.
+We have certificates generated and configuration for proxy ready. Now we need to add the proxy to our ``compose.yml`` file so we can run the whole FDP behind the proxy.
 
 .. code-block:: yaml
    :substitutions:
     
-    # docker-compose.yml
+    # compose.yml
 
-    version: '3'
     services:
         proxy:
             image: nginx:1.17.3
@@ -152,7 +151,7 @@ The last thing to do is to update our ``application.yml`` file. We need to add `
 
 
 
-At this point, we should be able to run all the containers using ``docker-compose up -d`` and after everything starts, we can access the FAIR Data Point at https://fdp.example.com. Of course, the domain you want to access the FDP on must be configured to the server where it runs.
+At this point, we should be able to run all the containers using ``docker compose up -d`` and after everything starts, we can access the FAIR Data Point at https://fdp.example.com. Of course, the domain you want to access the FDP on must be configured to the server where it runs.
 
 .. DANGER::
 

--- a/docs/deployment/production-deployment.rst
+++ b/docs/deployment/production-deployment.rst
@@ -121,11 +121,12 @@ We have certificates generated and configuration for proxy ready. Now we need to
             volumes:
                 - ./mongo/data:/data/db
 
-        blazegraph:
-            image: metaphacts/blazegraph-basic:2.2.0-20160908.003514-6
+        graphdb:
+            image: ontotext/graphdb:10.7.6
             volumes:
-                - ./blazegraph:/blazegraph-data
+                - ./graphdb:/opt/graphdb/home
 
+Don't forget to create the GraphDB repository as described in the :ref:`Persistent Repository <persistent-repository>` section.
 
 The last thing to do is to update our ``application.yml`` file. We need to add ``clientUrl`` so that FDP knows the actual URL even if hidden behind the reverse proxy. It's a good practice to set up a persistent URL for the metadata too. We recommend using ``https://purl.org``. If you don't specify ``persistentUrl``, the ``clientUrl`` will be used instead. And we also need to set a random JWT token for security.
 
@@ -144,9 +145,10 @@ The last thing to do is to update our ``application.yml`` file. We need to add `
 
     # repository settings (can be changed to different repository)
     repository:
-        type: 5
-        blazegraph:
-            url: http://blazegraph:8080/blazegraph
+        type: 4
+        graphDb:
+            url: http://graphdb:7200
+            repository: fdp
 
 
 

--- a/docs/deployment/production-deployment.rst
+++ b/docs/deployment/production-deployment.rst
@@ -148,6 +148,9 @@ The last thing to do is to update our ``application.yml`` file. We need to add `
         graphDb:
             url: http://graphdb:7200
             repository: fdp
+            # if your graphdb has the security feature enabled, configure the credentials below
+            username: ...
+            password: ...
 
 
 


### PR DESCRIPTION
- [x] describe the manual steps of creating a repository
- [x] link to or describe creating a repository in `production-deployment.rst` as well

also fixes #53