### PR TITLE
Multiline paragraphs

### DIFF
--- a/docs/about/about.rst
+++ b/docs/about/about.rst
@@ -2,13 +2,8 @@
 About FAIR Data Point
 *********************
 
-
-**FAIRDataPoint** is a REST API and Web Client for creating, storing, and serving
-**FAIR metadata**. The metadata contents are generated
-**semi-automatically** according to the `FAIR Data Point software
-specification <https://github.com/FAIRDataTeam/FAIRDataPoint-Spec>`__
-document.
-
+**FAIRDataPoint** is a REST API and Web Client for creating, storing, and serving **FAIR metadata**.
+The metadata contents are generated **semi-automatically** according to the `FAIR Data Point software specification <https://github.com/FAIRDataTeam/FAIRDataPoint-Spec>`__ document.
 
 Features
 --------
@@ -20,8 +15,14 @@ Features
 Security
 --------
 
-We have two levels of accessibility in FDP. All resources (e.g., catalogs, datasets,...) are publicly accessible. You don't need to be logged in to browse them. If you want to upload your own resources, you need to be logged in. To get an account, you need to contact an administrator of the FDP. By default, all uploaded resources are publicly accessible by anyone. But if you want to allow someone to manage your resources (edit/delete), you need to allow it in the resource settings. 
+We have two levels of accessibility in FDP.
+All resources (e.g., catalogs, datasets,...) are publicly accessible.
+You don't need to be logged in to browse them.
+If you want to upload your own resources, you need to be logged in.
+To get an account, you need to contact an administrator of the FDP.
+By default, all uploaded resources are publicly accessible by anyone.
+But if you want to allow someone to manage your resources (edit/delete), you need to allow it in the resource settings.
 
-We have two types of roles in FDP - an administrator and a user. The administrator is allowed to manage users and all resources. The user can manage just the resources which he owns.
-
-
+We have two types of roles in FDP - an administrator and a user.
+The administrator is allowed to manage users and all resources.
+The user can manage just the resources which he owns.

--- a/docs/about/components.rst
+++ b/docs/about/components.rst
@@ -4,7 +4,8 @@
 Components
 **********
 
-The deployment of the FAIR Data Point consists of a couple of components. See the following image for the overview:
+The deployment of the FAIR Data Point consists of a couple of components.
+See the following image for the overview:
 
 .. image:: structure-overview.png
    :alt: Structure Overview
@@ -14,28 +15,36 @@ The deployment of the FAIR Data Point consists of a couple of components. See th
 Triple Store
 ============
 
-Every FAIR Data Point needs to store the semantic data somewhere. A triple Store is a place where the data is. It is possible to configure different stores, see :ref:`Triple Stores configuration <triple-stores>` for more details.
+Every FAIR Data Point needs to store the semantic data somewhere.
+A triple Store is a place where the data is.
+It is possible to configure different stores, see :ref:`Triple Stores configuration <triple-stores>` for more details.
 
 
 MongoDB
 =======
 
-Besides semantic data, FDP needs information about user accounts and their roles. These data are stored in `MongoDB <https://www.mongodb.com>`__ database.
+Besides semantic data, FDP needs information about user accounts and their roles.
+These data are stored in `MongoDB <https://www.mongodb.com>`__ database.
 
 
 FAIRDataPoint
 =============
 
-FAIRDataPoint is distributed in Docker image ``fairdata/fairdatapoint``. It is the core component which handles all the business logic and operations with the semantic data. It also provides API for working with data in different formats.
+FAIRDataPoint is distributed in Docker image ``fairdata/fairdatapoint``.
+It is the core component which handles all the business logic and operations with the semantic data.
+It also provides API for working with data in different formats.
 
 
 FAIRDataPoint-client
 ====================
 
-FDP client is distributed in Docker image ``fairdata/fairdatapoint-client``. It provides the user interface for humans. It works as a reverse proxy in front of the FAIR Data Point which decides whether the request is for machine-readable data and passes it to the FAIRDataPoint or from a web browser in which case it serves the interface for humans.
+FDP client is distributed in Docker image ``fairdata/fairdatapoint-client``.
+It provides the user interface for humans.
+It works as a reverse proxy in front of the FAIR Data Point which decides whether the request is for machine-readable data and passes it to the FAIRDataPoint or from a web browser in which case it serves the interface for humans.
 
 
 Reverse Proxy
 =============
 
-In a production deployment, there is usually a reverse proxy that handles HTTPS certificates, so the connection to the FAIR Data Point is secured. See :ref:`production deployment <production-deployment>` to learn how to configure one.
+In a production deployment, there is usually a reverse proxy that handles HTTPS certificates, so the connection to the FAIR Data Point is secured.
+See :ref:`production deployment <production-deployment>` to learn how to configure one.

--- a/docs/deployment/advanced-configuration.rst
+++ b/docs/deployment/advanced-configuration.rst
@@ -9,7 +9,9 @@ Advanced Configuration
 Triple Stores
 =============
 
-FDP uses InMemory triple store by default. In previous examples, there is Blazegraph used. However, you can choose from 3 additional options.
+FDP uses InMemory triple store by default.
+In previous examples, there is Blazegraph used.
+However, you can choose from 3 additional options.
 
 **List of possible triple stores:**
 
@@ -22,7 +24,8 @@ FDP uses InMemory triple store by default. In previous examples, there is Blazeg
 1. In-Memory Store
 ------------------
 
-There is no need to configure additional properties to run FDP with In-Memory Store because it's the default option. If you want to explicitly type in configuration provided in ``application.yml``, add following lines there:
+There is no need to configure additional properties to run FDP with In-Memory Store because it's the default option.
+If you want to explicitly type in configuration provided in ``application.yml``, add following lines there:
 
 .. code-block:: yaml
     
@@ -34,7 +37,8 @@ There is no need to configure additional properties to run FDP with In-Memory St
 2. Native Store
 ---------------
 
-With this option, FDP will simply save the data to the file system. If you want to use the Native Store, make sure that you have these lines in your ``application.yml`` file:
+With this option, FDP will simply save the data to the file system.
+If you want to use the Native Store, make sure that you have these lines in your ``application.yml`` file:
 
 .. code-block:: yaml
     
@@ -50,7 +54,8 @@ where ``/tmp/fdp-store`` is a path to a location where you want to keep your dat
 3. Allegro Graph
 ----------------
 
-For running `Allegro Graph <https://franz.com/agraph/allegrograph/>`_, you need to first set up your Allegro Graph instance. For configuring the connection from FDP, add these lines to your ``application.yml`` file:
+For running `Allegro Graph <https://franz.com/agraph/allegrograph/>`_, you need to first set up your Allegro Graph instance.
+For configuring the connection from FDP, add these lines to your ``application.yml`` file:
 
 .. code-block:: yaml
     
@@ -69,7 +74,8 @@ For running `Allegro Graph <https://franz.com/agraph/allegrograph/>`_, you need 
 4. GraphDB
 ----------
 
-For running `GraphDB <http://graphdb.ontotext.com>`_, you need to first set up your GraphDB instance and **create the repository**. For configuring the connection from FDP, add these lines to your ``application.yml`` file:
+For running `GraphDB <http://graphdb.ontotext.com>`_, you need to first set up your GraphDB instance and **create the repository**.
+For configuring the connection from FDP, add these lines to your ``application.yml`` file:
 
 .. code-block:: yaml
     
@@ -84,11 +90,11 @@ For running `GraphDB <http://graphdb.ontotext.com>`_, you need to first set up y
 
 ``URL`` and ``repository`` should be configured according to your actual GraphDB setup.
 
-
 5. Blazegraph
 -------------
 
-For running `Blazegraph <https://blazegraph.com/>`_, you need to first set up your Blazegraph instance. For configuring the connection from FDP, add these lines to your ``application.yml`` file:
+For running `Blazegraph <https://blazegraph.com/>`_, you need to first set up your Blazegraph instance.
+For configuring the connection from FDP, add these lines to your ``application.yml`` file:
 
 .. code-block:: yaml
     
@@ -101,12 +107,15 @@ For running `Blazegraph <https://blazegraph.com/>`_, you need to first set up yo
             repository:
 
 
-``URL`` and ``repository`` should be configured according to your actual Blazegraph setup. Repository should be set only if you don't use the default one.
+``URL`` and ``repository`` should be configured according to your actual Blazegraph setup.
+Repository should be set only if you don't use the default one.
 
 
 Mongo DB
 ========
-We store users, permissions, etc. in the `MongoDB database <https://www.mongodb.com/>`_. The default connection string is ``mongodb://mongo:27017/fdp``. If you want to modify it, add these lines to your ``application.yml`` file:
+We store users, permissions, etc. in the `MongoDB database <https://www.mongodb.com/>`_.
+The default connection string is ``mongodb://mongo:27017/fdp``.
+If you want to modify it, add these lines to your ``application.yml`` file:
 
 .. code-block:: yaml
     
@@ -119,10 +128,13 @@ We store users, permissions, etc. in the `MongoDB database <https://www.mongodb.
 
 The ``uri`` should be adjusted by your actual MongoDB setup.
 
+
 Default attached metadata
 =========================
 
-There are several default values that are attached to each created metadata. If you want to modify it, add the lines below to your ``application.yml`` file. The default values are listed below, too:
+There are several default values that are attached to each created metadata.
+If you want to modify it, add the lines below to your ``application.yml`` file.
+The default values are listed below, too:
 
 .. code-block:: yaml
     
@@ -136,6 +148,7 @@ There are several default values that are attached to each created metadata. If 
     metadataMetrics:
         https://purl.org/fair-metrics/FM_F1A: https://www.ietf.org/rfc/rfc3986.txt
         https://purl.org/fair-metrics/FM_A1.1: https://www.wikidata.org/wiki/Q8777
+
 
 FDP Index
 =========
@@ -155,7 +168,9 @@ To enable FDP Index mode on your FDP server, just simply adjust your ``applicati
         index:  true
 
 
-Then for the FDP client, you need to use ``fairdata/fairdatapoint-index-client`` Docker image for browsing indexed FDPs and searching harvested metadata. In case you want to use your deployment both as FDP and FDP Index, you can deploy both FDP and FDP Index client applications. The configuration of both clients are identical.
+Then for the FDP client, you need to use ``fairdata/fairdatapoint-index-client`` Docker image for browsing indexed FDPs and searching harvested metadata.
+In case you want to use your deployment both as FDP and FDP Index, you can deploy both FDP and FDP Index client applications.
+The configuration of both clients are identical.
 
 .. code-block:: yaml
    :substitutions:
@@ -176,7 +191,8 @@ Then for the FDP client, you need to use ``fairdata/fairdatapoint-index-client``
 Connecting to FDP Index
 -----------------------
 
-By default, FDPs use https://home.fairdatapoint.org as their primary FDP Index that they ping every 7 days. You can adjust that in  your ``application.yml`` file if needed:
+By default, FDPs use https://home.fairdatapoint.org as their primary FDP Index that they ping every 7 days.
+You can adjust that in  your ``application.yml`` file if needed:
 
 .. code-block:: yaml
     
@@ -202,7 +218,9 @@ You can also set multiple endpoints if needed:
 FDP Index behind proxy
 ----------------------
 
-FDP Index uses IP-based rate limits to avoid excessive communication caused by bots or misconfigured FDPs. If the FDP Index is deployed behind a proxy, it must correctly set header, e.g., ``X-Forwarded-For``. Furthermore, you need to add this to ``application.yml``:
+FDP Index uses IP-based rate limits to avoid excessive communication caused by bots or misconfigured FDPs.
+If the FDP Index is deployed behind a proxy, it must correctly set header, e.g., ``X-Forwarded-For``.
+Furthermore, you need to add this to ``application.yml``:
 
 .. code-block:: yaml
     
@@ -212,16 +230,16 @@ FDP Index uses IP-based rate limits to avoid excessive communication caused by b
         forward-headers-strategy: NATIVE
 
 
-There may be differences based on you specific deployment. You should check in logs, which IP address is used when ping is received.
+There may be differences based on you specific deployment.
+You should check in logs, which IP address is used when ping is received.
 
 
 Customizations
 ==============
 
-You can customize the look and feel of FDP Client using
-`SCSS <https://sass-lang.com>`__. There are three files you can mount to
-``/src/scss/custom``. If there are any changes in these files, the
-styles will be regenerated when FDP Client starts.
+You can customize the look and feel of FDP Client using `SCSS <https://sass-lang.com>`__.
+There are three files you can mount to ``/src/scss/custom``.
+If there are any changes in these files, the styles will be regenerated when FDP Client starts.
 
 Customization files
 -------------------
@@ -229,10 +247,9 @@ Customization files
 _variables.scss
 ~~~~~~~~~~~~~~~
 
-A lot of values related to styles are defined as variables. The easiest
-way to customize the FDP Client is to define new values for these
-variables. To do so, you create a file called ``_variables.scss`` where
-you define the values that you want to change.
+A lot of values related to styles are defined as variables.
+The easiest way to customize the FDP Client is to define new values for these variables.
+To do so, you create a file called ``_variables.scss`` where you define the values that you want to change.
 
 Here is an example of changing the primary color.
 
@@ -248,14 +265,14 @@ to see all the variables you can change.
 _extra.scss
 ~~~~~~~~~~~
 
-This file is loaded before all other styles. You can use it, for
-example, to define new styles or import fonts.
+This file is loaded before all other styles.
+You can use it, for example, to define new styles or import fonts.
 
 _overrides.scss
 ~~~~~~~~~~~~~~~
 
-This file is loaded after all other styles. You can use it to override
-existing styles.
+This file is loaded after all other styles.
+You can use it to override existing styles.
 
 Example of setting a custom logo
 --------------------------------
@@ -296,11 +313,10 @@ To change the logo, you need to do three steps:
 Running FDP on a nested route
 ==============================
 
-Sometimes, you might want to run FDP alongside other applications on the
-same domain. Here is an example of running FDP on
-``https://example.com/fairdatapoint``. If you run FDP in this configuration, you
-have to set ``PUBLIC\_PATH`` ENV variable, in this example to
-``/fairdatapoint``. Also, don't forget to set correct client URL in the application config.
+Sometimes, you might want to run FDP alongside other applications on the same domain.
+Here is an example of running FDP on ``https://example.com/fairdatapoint``.
+If you run FDP in this configuration, you have to set ``PUBLIC\_PATH`` ENV variable, in this example to ``/fairdatapoint``.
+Also, don't forget to set correct client URL in the application config.
 
 .. code-block:: yaml
    :substitutions:
@@ -320,7 +336,7 @@ have to set ``PUBLIC\_PATH`` ENV variable, in this example to
             ports:
                 - 80:80
             environment:
-            	- FDP_HOST=fdp
+                - FDP_HOST=fdp
                 - PUBLIC_PATH=/fairdatapoint
 
 .. code-block:: yaml

--- a/docs/deployment/local-deployment.rst
+++ b/docs/deployment/local-deployment.rst
@@ -2,7 +2,9 @@
 Local Deployment
 ****************
 
-FAIR Data Point is distributed in Docker images. For a simple local deployment, you need to run ``fairdatapoint``, ``fairdatapoint-client`` and ``mongo`` images. See the :ref:`Components <components>` section to read more about what each image is for.
+FAIR Data Point is distributed in Docker images.
+For a simple local deployment, you need to run ``fairdatapoint``, ``fairdatapoint-client`` and ``mongo`` images.
+See the :ref:`Components <components>` section to read more about what each image is for.
 
 Here is an example of the simplest `Docker Compose <https://docs.docker.com/compose/>`__ configuration to run FDP.
 
@@ -27,10 +29,15 @@ Here is an example of the simplest `Docker Compose <https://docs.docker.com/comp
             image: mongo:4.0.12
 
 
-Then you can run it using ``docker compose up -d``. It might take a while to start. You can run ``docker compose logs -f`` to follow the output log. Once you see a message, that the application started, the FAIR Data Point should be working, and you can open http://localhost.
+Then you can run it using ``docker compose up -d``.
+It might take a while to start.
+You can run ``docker compose logs -f`` to follow the output log.
+Once you see a message, that the application started, the FAIR Data Point should be working, and you can open http://localhost.
 
 
-There are two default user accounts. See the :ref:`Users and Roles <users-and-roles>` section to read more about users and roles. The default accounts are
+There are two default user accounts.
+See the :ref:`Users and Roles <users-and-roles>` section to read more about users and roles.
+The default accounts are
 
 +-----------------------------+-------+----------+
 | User name                   | Role  | Password |
@@ -48,7 +55,8 @@ There are two default user accounts. See the :ref:`Users and Roles <users-and-ro
 Running locally on a different port
 ===================================
 
-If you want to run the FAIR Data Point locally on a different port than the default ``80``, additional configuration is necessary. First, we need to create a new file ``application.yml`` and set the client URL to the actual URL we want to use.
+If you want to run the FAIR Data Point locally on a different port than the default ``80``, additional configuration is necessary.
+First, we need to create a new file ``application.yml`` and set the client URL to the actual URL we want to use.
 
 .. code-block:: yaml
 
@@ -85,13 +93,16 @@ Then, we need to mount the application config into the FDP container and update 
 Persistence
 ===========
 
-We don't have any data persistence with the previous configuration. Once we remove the containers, all the data will be lost. To keep it, we need to configure MongoDB volume and persistent triple store.
+We don't have any data persistence with the previous configuration.
+Once we remove the containers, all the data will be lost.
+To keep it, we need to configure MongoDB volume and persistent triple store.
 
 
 MongoDB volume
 --------------
 
-We use MongoDB to store information about user accounts and access permissions. We can configure a `volume <https://docs.docker.com/storage/volumes/>`__ so that the data keep on our disk even if we delete MongoDB container.
+We use MongoDB to store information about user accounts and access permissions.
+We can configure a `volume <https://docs.docker.com/storage/volumes/>`__ so that the data keep on our disk even if we delete MongoDB container.
 
 We can also expose port ``27017`` so we can access MongoDB from our local computer using a client application like `Robo 3T <https://robomongo.org>`__.
 
@@ -127,11 +138,15 @@ Here is the updated docker compose file:
 Persistent Repository
 -----------------------
 
-FAIR Data Point uses repositories to store the metadata. By default, it uses the in-memory store, which means that the data is lost after the FDP is stopped.
+FAIR Data Point uses repositories to store the metadata.
+By default, it uses the in-memory store, which means that the data is lost after the FDP is stopped.
 
-In this example, we will configure GraphDB as a triple store. See :ref:`Triple Stores <triple-stores>` for other repository options.
+In this example, we will configure GraphDB as a triple store.
+See :ref:`Triple Stores <triple-stores>` for other repository options.
 
-If we don't have it already, we need to create a new file ``application.yml``. We will use this file to configure the repository and mount it as a read-only volume to the ``fdp`` container. This file can be used for other configuration, see :ref:`Advanced Configuration <advanced-configuration>` for more details.
+If we don't have it already, we need to create a new file ``application.yml``.
+We will use this file to configure the repository and mount it as a read-only volume to the ``fdp`` container.
+This file can be used for other configuration, see :ref:`Advanced Configuration <advanced-configuration>` for more details.
 
 
 .. code-block:: yaml
@@ -146,7 +161,8 @@ If we don't have it already, we need to create a new file ``application.yml``. W
             url: http://graphdb:7200
             repository: fdp
 
-We now need to update our ``compose.yml`` file, we add a new volume for the ``fdp`` and add ``graphdb`` service. We can also expose port ``7200`` for GraphDB so we can access its user interface.
+We now need to update our ``compose.yml`` file, we add a new volume for the ``fdp`` and add ``graphdb`` service.
+We can also expose port ``7200`` for GraphDB so we can access its user interface.
 
 .. code-block:: yaml
    :substitutions:
@@ -181,7 +197,8 @@ We now need to update our ``compose.yml`` file, we add a new volume for the ``fd
             volumes:
                 - ./graphdb:/opt/graphdb/home
 
-GraphDB needs to have a repository set up before the FDP can interact with it. This can be done manually through the user interface, following these steps:
+GraphDB needs to have a repository set up before the FDP can interact with it.
+This can be done manually through the user interface, following these steps:
 
 - Start only the GraphDB container: ``docker compose up -d graphdb``
 - Navigate to your `local GraphDB instance <http://localhost:7200>`__
@@ -236,7 +253,8 @@ Alternatively, these steps can be automated with the following addition to the `
                 test: curl --fail-with-body http://localhost:7200/repositories/fdp/health || exit 1
                 interval: 5s
 
-The ``repo.json`` file contains the configuration for the newly created GraphDB repository. The following is a bare minimum example.
+The ``repo.json`` file contains the configuration for the newly created GraphDB repository.
+The following is a bare minimum example.
 
 .. code-block:: json
 

--- a/docs/deployment/production-deployment.rst
+++ b/docs/deployment/production-deployment.rst
@@ -4,13 +4,20 @@
 Production Deployment
 *********************
 
-If you want to run the FAIR Data Point in production it is recommended to use HTTPS protocol with valid certificates. You can easily configure FDP to run behind a reverse proxy which takes care of the certificates.
+If you want to run the FAIR Data Point in production it is recommended to use HTTPS protocol with valid certificates.
+You can easily configure FDP to run behind a reverse proxy which takes care of the certificates.
 
-In this example, we will configure FDP to run on ``https://fdp.example.com``. We will see how to configure the reverse proxy in the same Docker Compose file. However, it is not necessary, and the proxy can be configured elsewhere.
+In this example, we will configure FDP to run on ``https://fdp.example.com``.
+We will see how to configure the reverse proxy in the same Docker Compose file.
+However, it is not necessary, and the proxy can be configured elsewhere.
 
-First of all, we need to generate the certificates on the server where we want to run the FDP. You can use `Let's Encrypt <https://letsencrypt.org>`__ and create the certificates with `certbot <https://certbot.eff.org>`__. The certificates are generated in a standard location, e.g., ``/etc/letsencrypt/live/fdp.example.com`` for ``fdp.example.com`` domain. We will mount the whole ``letsencrypt`` folder to the reverse proxy container later so that it can use the certificates.
+First of all, we need to generate the certificates on the server where we want to run the FDP.
+You can use `Let's Encrypt <https://letsencrypt.org>`__ and create the certificates with `certbot <https://certbot.eff.org>`__.
+The certificates are generated in a standard location, e.g., ``/etc/letsencrypt/live/fdp.example.com`` for ``fdp.example.com`` domain.
+We will mount the whole ``letsencrypt`` folder to the reverse proxy container later so that it can use the certificates.
 
-As a reverse proxy, we will use `nginx <http://nginx.org/en/>`__. We need to prepare some configuration, so create a new folder called ``nginx`` with the following structure and files:
+As a reverse proxy, we will use `nginx <http://nginx.org/en/>`__.
+We need to prepare some configuration, so create a new folder called ``nginx`` with the following structure and files:
 
 ::
 
@@ -21,7 +28,8 @@ As a reverse proxy, we will use `nginx <http://nginx.org/en/>`__. We need to pre
   └ sites-enabled
      └ fdp.conf -> ../sites-available/fdp.conf
 
-The file ``nginx.conf`` is the configuration of the whole nginx, and it includes all the files from ``sites-enabled`` which contains configuration for individual servers (we can use one nginx, for example, to handle multiple servers on different domains). All available configurations for different servers are in the ``sites-available``, but only those linked to ``sites-enabled`` are used.
+The file ``nginx.conf`` is the configuration of the whole nginx, and it includes all the files from ``sites-enabled`` which contains configuration for individual servers (we can use one nginx, for example, to handle multiple servers on different domains).
+All available configurations for different servers are in the ``sites-available``, but only those linked to ``sites-enabled`` are used.
 
 Let's see what should be the content of the configuration files.
 
@@ -84,7 +92,8 @@ Finally, we need to create a soft link from sites-enabled to sites-available for
 
     $ cd nginx/sites-enabled && ln -s ../sites-available/fdp.conf
 
-We have certificates generated and configuration for proxy ready. Now we need to add the proxy to our ``compose.yml`` file so we can run the whole FDP behind the proxy.
+We have certificates generated and configuration for proxy ready.
+Now we need to add the proxy to our ``compose.yml`` file so we can run the whole FDP behind the proxy.
 
 .. code-block:: yaml
    :substitutions:
@@ -127,7 +136,12 @@ We have certificates generated and configuration for proxy ready. Now we need to
 
 Don't forget to create the GraphDB repository as described in the :ref:`Persistent Repository <persistent-repository>` section.
 
-The last thing to do is to update our ``application.yml`` file. We need to add ``clientUrl`` so that FDP knows the actual URL even if hidden behind the reverse proxy. It's a good practice to set up a persistent URL for the metadata too. We recommend using ``https://purl.org``. If you don't specify ``persistentUrl``, the ``clientUrl`` will be used instead. And we also need to set a random JWT token for security.
+The last thing to do is to update our ``application.yml`` file.
+We need to add ``clientUrl`` so that FDP knows the actual URL even if hidden behind the reverse proxy.
+It's a good practice to set up a persistent URL for the metadata too.
+We recommend using ``https://purl.org``.
+If you don't specify ``persistentUrl``, the ``clientUrl`` will be used instead.
+And we also need to set a random JWT token for security.
 
 .. code-block:: yaml
 
@@ -154,7 +168,8 @@ The last thing to do is to update our ``application.yml`` file. We need to add `
 
 
 
-At this point, we should be able to run all the containers using ``docker compose up -d`` and after everything starts, we can access the FAIR Data Point at https://fdp.example.com. Of course, the domain you want to access the FDP on must be configured to the server where it runs.
+At this point, we should be able to run all the containers using ``docker compose up -d`` and after everything starts, we can access the FAIR Data Point at https://fdp.example.com.
+Of course, the domain you want to access the FDP on must be configured to the server where it runs.
 
 .. DANGER::
 
@@ -167,7 +182,9 @@ At this point, we should be able to run all the containers using ``docker compos
 
 .. WARNING::
 
-    In order to improve findability of itself and its content, the FAIR Data Point has a built-in feature that registers its URL into our server and pings it once a week. This feature facilitates the indexing of the metadata of each registered and active FAIR Data Point. If you do not want your FAIR Data Point to be included in this registry, add these lines to your application configuration:
+    In order to improve findability of itself and its content, the FAIR Data Point has a built-in feature that registers its URL into our server and pings it once a week.
+    This feature facilitates the indexing of the metadata of each registered and active FAIR Data Point.
+    If you do not want your FAIR Data Point to be included in this registry, add these lines to your application configuration:
 
     .. code-block:: yaml
 

--- a/docs/development/changelog.rst
+++ b/docs/development/changelog.rst
@@ -5,7 +5,8 @@ Changelog
 Overview
 ========
 
-Here we summarize the key features and changes for each FAIR Data Point release. For details including bugfixes and minor changes, see :ref:`detailed-changelog`.
+Here we summarize the key features and changes for each FAIR Data Point release.
+For details including bugfixes and minor changes, see :ref:`detailed-changelog`.
 
 1.16
 ------
@@ -147,9 +148,8 @@ Here we summarize the key features and changes for each FAIR Data Point release.
 Detailed changelog
 ==================
 
-Each of components developed has its own Changelog based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
-and our projects adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_. It is recommended to use matching
-versions of all components.
+Each of components developed has its own Changelog based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and our projects adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
+It is recommended to use matching versions of all components.
 
 - `FAIR Data Point Changelog <https://github.com/FAIRDataTeam/FAIRDataPoint/blob/develop/CHANGELOG.md>`_
 - `FAIR Data Point Client Changelog <https://github.com/FAIRDataTeam/FAIRDataPoint-client/blob/develop/CHANGELOG.md>`_

--- a/docs/openrefine/setup.rst
+++ b/docs/openrefine/setup.rst
@@ -8,12 +8,14 @@ This part describes how to set up your own OpenRefine with the **metadata** exte
 Installation
 ============
 
-There are two ways of using our **metadata** extension for OpenRefine. You can have installed OpenRefine and add extension to it or use Docker with our prepared image.
+There are two ways of using our **metadata** extension for OpenRefine.
+You can have installed OpenRefine and add extension to it or use Docker with our prepared image.
 
 Installed OpenRefine
 --------------------
 
-This option requires you to have installed compatible version of OpenRefine, please check :ref:`openrefine-compatibility`. In case you need to install OpenRefine first, visit their `documentation <https://github.com/OpenRefine/OpenRefine/wiki/Installation-Instructions>`_. 
+This option requires you to have installed compatible version of OpenRefine, please check :ref:`openrefine-compatibility`.
+In case you need to install OpenRefine first, visit their `documentation <https://github.com/OpenRefine/OpenRefine/wiki/Installation-Instructions>`_.
 
 * Get the desired version of the **metadata** extension from `our GitHub releases page <https://github.com/FAIRDataTeam/OpenRefine-metadata-extension/releases>`_ by downloading tgz or zip archive, e.g., ``metadata-X.Y.Z-OpenRefine-X.Y.zip``.
 * Extract the archive to ``extensions`` folder of your OpenRefine (see `OpenRefine documentation <https://github.com/OpenRefine/OpenRefine/wiki/Installing-Extensions>`_).
@@ -26,13 +28,18 @@ This option requires you to have installed compatible version of OpenRefine, ple
 With Docker
 -----------
 
-If you want to use Docker, we provide a Docker image `fairdata/openrefine-metadata-extension <https://hub.docker.com/r/fairdata/openrefine-metadata-extension>`_ that combines the extension with OpenRefine of supported version. It is of course possible to use volume for the ``data`` directory (eventually ``data/extensions`` to include other extensions). All you need to have is Docker running and then:
+If you want to use Docker, we provide a Docker image `fairdata/openrefine-metadata-extension <https://hub.docker.com/r/fairdata/openrefine-metadata-extension>`_ that combines the extension with OpenRefine of supported version.
+It is of course possible to use volume for the ``data`` directory (eventually ``data/extensions`` to include other extensions).
+All you need to have is Docker running and then:
 
 ::
 
    docker run -p 3333:3333 -v /home/me/openrefine-data:/data:z fairdata/openrefine-metadata-extension
 
-This will run the OpenRefine with **metadata** extension on port 3333 that will be exposed and mounts your folder ``/home/me/openrefine-data`` as OpenRefine data folder. You should be able to open OpenRefine in browser on ``localhost:3333``. If there are some other extensions in ``/home/me/openrefine-data/extensions``, those should be loaded as well. For more information, see `OpenRefine documentation <https://github.com/OpenRefine/OpenRefine/wiki/Installing-Extensions>`_.
+This will run the OpenRefine with **metadata** extension on port 3333 that will be exposed and mounts your folder ``/home/me/openrefine-data`` as OpenRefine data folder.
+You should be able to open OpenRefine in browser on ``localhost:3333``.
+If there are some other extensions in ``/home/me/openrefine-data/extensions``, those should be loaded as well.
+For more information, see `OpenRefine documentation <https://github.com/OpenRefine/OpenRefine/wiki/Installing-Extensions>`_.
 
 For configuration files you need to mount ``/webapp/extensions/metadata/module/config``, see :ref:`openrefine-configuration` for more details.
 
@@ -42,14 +49,18 @@ For configuration files you need to mount ``/webapp/extensions/metadata/module/c
 Configuration
 =============
 
-Configuration files of the **metadata** extension use the :abbr:`YAML (YAML Ain't Markup Language)` format and are stored in ``extensions/metadata/module/config`` directory of the used OpenRefine installment. The configuration files are loaded when OpenRefine is started. Therefore, you are required to restart OpenRefine before changes in configuration files take effect. We provide `examples <https://github.com/FAIRDataTeam/OpenRefine-metadata-extension/tree/develop/src/main/resources/module/config>`_ of the configuration files that you can (re)use.
+Configuration files of the **metadata** extension use the :abbr:`YAML (YAML Ain't Markup Language)` format and are stored in ``extensions/metadata/module/config`` directory of the used OpenRefine installment.
+The configuration files are loaded when OpenRefine is started.
+Therefore, you are required to restart OpenRefine before changes in configuration files take effect.
+We provide `examples <https://github.com/FAIRDataTeam/OpenRefine-metadata-extension/tree/develop/src/main/resources/module/config>`_ of the configuration files that you can (re)use.
 
 .. _openrefine-configuration-settings:
 
 Settings
 --------
 
-Settings configuration file serves for generic configuration options that adjust behaviour of the extension. The structure of the file is following:
+Settings configuration file serves for generic configuration options that adjust behaviour of the extension.
+The structure of the file is following:
 
 * ``allowCustomFDP`` (boolean) = should be user allowed to enter custom FAIR Data Point :abbr:`URI (Uniform Resource Identifier)`, username, and password (or use only the pre-configured)
 * ``metadata`` (map) = key-value specification of instance-wide pre-defined metadata, e.g., set ``license`` to ``http://purl.org/NET/rdflicense/cc-by3.0`` and that :abbr:`URI (Uniform Resource Identifier)` will be pre-set in all metadata forms in field ``license`` (but can be overwritten by the user)
@@ -69,13 +80,15 @@ For more information and further configuration options, see `settings example <h
 Storages
 --------
 
-Storages configuration file holds details about storages that are possible to use for :ref:`openrefine-store-data` feature. In the file, list of storage object is expected where each of them has:
+Storages configuration file holds details about storages that are possible to use for :ref:`openrefine-store-data` feature.
+In the file, list of storage object is expected where each of them has:
 
 * ``name`` (string) = custom name identifying the storage
 * ``type`` (string) = one of the allowed types (others are ignored): ``ftp``, ``virtuso``, ``tripleStoreHTTP``
 * ``details`` (object) = configuration related to specific type of storage (see `storages example <https://github.com/FAIRDataTeam/OpenRefine-metadata-extension/blob/master/src/main/resources/module/config/storages.example.yaml>`_)
 
-For :abbr:`FTP (File Transfer Protocol)` and Virtuoso, ``directory`` should containt absolute path where files should be stored. In case of triple stores, repository name is used to specify the target location.
+For :abbr:`FTP (File Transfer Protocol)` and Virtuoso, ``directory`` should containt absolute path where files should be stored.
+In case of triple stores, repository name is used to specify the target location.
 
 .. _openrefine-compatibility:
 

--- a/docs/openrefine/usage.rst
+++ b/docs/openrefine/usage.rst
@@ -7,7 +7,8 @@ Here you can read how to use the **metadata** extension for OpenRefine to store 
 About metadata extension
 ========================
 
-The **metadata** extension for OpenRefine promotes FAIRness of the data by its integration with FAIR Data Point. With the extension you can easily FAIRify your data that you work on in directly in OpenRefine in two steps:
+The **metadata** extension for OpenRefine promotes FAIRness of the data by its integration with FAIR Data Point.
+With the extension you can easily FAIRify your data that you work on in directly in OpenRefine in two steps:
 
 1. :ref:`openrefine-store-data` in configured storage.
 2. :ref:`openrefine-create-metadata` in selected FAIR Data Point.

--- a/docs/usage/api-usage.rst
+++ b/docs/usage/api-usage.rst
@@ -4,7 +4,9 @@
 API Usage
 *********
 
-The **FAIR Data Point** exposes API endpoints that allow consumers to interact with the metadata. Some of the endpoints are available for all users, while others require an API token for authorization.
+The **FAIR Data Point** exposes API endpoints that allow consumers to interact with the metadata.
+Some of the endpoints are available for all users, while others require an API token for authorization.
+
 
 Obtaining an API token
 ======================
@@ -27,17 +29,20 @@ A successful call will return a ``JSON`` object with a token.
 Issueing a request with the authorization token
 ------------------------------------------------
 
-Subsequent requests should use this token in the `Authorization` header. The authorization type is a `Bearer <https://tools.ietf.org/html/rfc6750>`_ token.
+Subsequent requests should use this token in the `Authorization` header.
+The authorization type is a `Bearer <https://tools.ietf.org/html/rfc6750>`_ token.
 
 .. code :: bash
 
     curl -H "Authorization: Bearer efIobn394nvJJFJ30..." \
         -H "Accept: application/json" https://fdp.example.com/users
 
+
 Interacting with metadata
 =========================
 
-The metadata layers as defined by the :ref:`resource-definitions` are exposed through their respective endpoints. The general approach is that each layer, defined by its ``prefix``, supports a number of read and write HTTP methods.
+The metadata layers as defined by the :ref:`resource-definitions` are exposed through their respective endpoints.
+The general approach is that each layer, defined by its ``prefix``, supports a number of read and write HTTP methods.
 
 ======== ====================== ========================
 Method   URL pattern            Functionality
@@ -52,7 +57,8 @@ Method   URL pattern            Functionality
 Retrieving metadata
 -------------------
 
-Retrieving metadata is open for GET requests without authorization. In the following example, we retrieve a ``Dataset`` resource by issuing a ``GET`` request to the ``/dataset`` prefix followed by its identifier (a UUID).
+Retrieving metadata is open for GET requests without authorization.
+In the following example, we retrieve a ``Dataset`` resource by issuing a ``GET`` request to the ``/dataset`` prefix followed by its identifier (a UUID).
 
 .. code :: bash
 
@@ -63,7 +69,8 @@ Retrieving metadata is open for GET requests without authorization. In the follo
 Creating metadata
 -----------------
 
-New metadata can be created by ``POST``-ing the content to the appropriate endpoint. First we will create a file called ``metadata.ttl`` to store our new metadata.
+New metadata can be created by ``POST``-ing the content to the appropriate endpoint.
+First we will create a file called ``metadata.ttl`` to store our new metadata.
 
 .. code :: turtle
 
@@ -86,7 +93,8 @@ This metadata can be created by the following ``POST`` request.
         -H "Content-Type: text/turtle" \
         -d @metadata.ttl https://fdp.example.com/dataset
 
-When created, the metadata is initially in a ``DRAFT`` state. To publish the metadata using the API you can issue the following ``PUT`` request to transistion the metadata from the ``DRAFT`` state to the ``PUBLISHED`` state.
+When created, the metadata is initially in a ``DRAFT`` state.
+To publish the metadata using the API you can issue the following ``PUT`` request to transistion the metadata from the ``DRAFT`` state to the ``PUBLISHED`` state.
 
 .. code :: bash
 
@@ -109,7 +117,9 @@ Existing metadata can be updated by issuing a ``PUT`` request with the request b
         -H "Content-Type: text/turtle" \
         -d @metadata.ttl https://fdp.example.com/dataset/79508287-a2a7-4ae2-95b3-3f595e3088cc
 
+
 API endpoint listing
 ====================
 
-The available APIs are documented using `OpenAPI <https://www.openapis.org/>`_. In the ``/swagger-ui.html`` endpoint the APIs are visualized through `Swagger UI <https://swagger.io/tools/swagger-ui/>`_.
+The available APIs are documented using `OpenAPI <https://www.openapis.org/>`_.
+In the ``/swagger-ui.html`` endpoint the APIs are visualized through `Swagger UI <https://swagger.io/tools/swagger-ui/>`_.

--- a/docs/usage/usage.rst
+++ b/docs/usage/usage.rst
@@ -7,9 +7,11 @@ Usage
 Resource definitions
 ====================
 
-The **FAIR Data Point** reference implementations introduces the concept of **Resource Definitions**. A resource definition captures housekeeping data about a metadata resource.
+The **FAIR Data Point** reference implementations introduces the concept of **Resource Definitions**.
+A resource definition captures housekeeping data about a metadata resource.
 
-Resource definitions can be accessed from the reference implementation user interface, in the dashboard of an admin user. Here the resource definitions can be managed.
+Resource definitions can be accessed from the reference implementation user interface, in the dashboard of an admin user.
+Here the resource definitions can be managed.
 
 Managing resource definitions
 -----------------------------
@@ -23,28 +25,42 @@ Creating resource definitions
 
 When creating a new resource definition, the user interface presents you a form where a resource can be defined through a number of properties.
 
-**Name** defines the human readable name for a resource definition. This name is used in the admin dashboard to identify the definitions, and does not affect a definition on the functional level. For example, for the default ``dcat:Dataset`` resource, the human readable name would be ``"Dataset"``.
+**Name** defines the human readable name for a resource definition.
+This name is used in the admin dashboard to identify the definitions, and does not affect a definition on the functional level.
+For example, for the default ``dcat:Dataset`` resource, the human readable name would be ``"Dataset"``.
 
-**URL Prefix** defines the URL path for a resource. This context path should be a unique identifier, unique in the scope of the other resource defined within the FAIR Data Point instance. For example, for the ``dcat:Dataset`` resource the prefix is ``dataset``.
+**URL Prefix** defines the URL path for a resource.
+This context path should be a unique identifier, unique in the scope of the other resource defined within the FAIR Data Point instance.
+For example, for the ``dcat:Dataset`` resource the prefix is ``dataset``.
 
-**Target Class URIs** links the :ref:`shape definitions <shapes>` to a resource definition. In the current implementation, each shape that should be applied to the resource must be listed here. The expected URI value must match the ``sh:targetClass`` value of the shape definition. A common example is to list the ``dcat:Resource`` shape target class along with the specific subclass for the resource, like ``dcat:Dataset``.
+**Target Class URIs** links the :ref:`shape definitions <shapes>` to a resource definition.
+In the current implementation, each shape that should be applied to the resource must be listed here.
+The expected URI value must match the ``sh:targetClass`` value of the shape definition.
+A common example is to list the ``dcat:Resource`` shape target class along with the specific subclass for the resource, like ``dcat:Dataset``.
 
-**Children** defines child resources, if any. This applies when the resource acts as a parent resource for other types of resources. Children are defined by the following properties to provide directives for both the server and the client side.
+**Children** defines child resources, if any.
+This applies when the resource acts as a parent resource for other types of resources.
+Children are defined by the following properties to provide directives for both the server and the client side.
 
-* *Child Resource* links to the child's *resource definition*. The child resource must be defined beforehand.
-* *Child Relation URI* defines the predicate IRI that links the parent to the child on the metadata instance level. A common example is the link from a ``dcat:Dataset`` to a ``dcat:Distribution``; these resources are linked by the ``dcat:distribution`` predicate.
+* *Child Resource* links to the child's *resource definition*.
+  The child resource must be defined beforehand.
+* *Child Relation URI* defines the predicate IRI that links the parent to the child on the metadata instance level.
+  A common example is the link from a ``dcat:Dataset`` to a ``dcat:Distribution``; these resources are linked by the ``dcat:distribution`` predicate.
 * *Child List View Title* defines a literal value to be displayed as a section header for the child resources in the user interface.
-* *Child List View Tags URI* defines the predicate IRI for values that are displayed in the user interface whenever the child resources are listed. A common example is ``dcat:theme`` for ``dcat:Dataset`` resources.
+* *Child List View Tags URI* defines the predicate IRI for values that are displayed in the user interface whenever the child resources are listed.
+  A common example is ``dcat:theme`` for ``dcat:Dataset`` resources.
 * *Child List View Metadata* defines predicate IRIs for values that are listed in the child resource summary.
 
-**External links** defines predicate IRIs and literal values to be displayed in the user interface for primary interaction with a resource. A common example is for the ``dcat:Distribution`` resource, ``dcat:accessURL`` is mapped to an ``Access URL`` literal, and displayed prominently in the user interface.
+**External links** defines predicate IRIs and literal values to be displayed in the user interface for primary interaction with a resource.
+A common example is for the ``dcat:Distribution`` resource, ``dcat:accessURL`` is mapped to an ``Access URL`` literal, and displayed prominently in the user interface.
 
 .. _modify-resource-definition:
 
 Modifying resource definitions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When modifying a resource definition, not all properties are writable. Some properties are write-protected to ensure the internal consistency of the system.
+When modifying a resource definition, not all properties are writable.
+Some properties are write-protected to ensure the internal consistency of the system.
 
 The **URL Prefix** and the **Target Class URIs** are not writable.
 
@@ -55,7 +71,9 @@ The other properties, like child resources and external links are writable, and 
 Deleting resource definitions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Deleting a resource definition should be used with caution. Existing metadata instances are no longer accessible after the resource definition is deleted. This includes child resources, if those are not linked to other resources.
+Deleting a resource definition should be used with caution.
+Existing metadata instances are no longer accessible after the resource definition is deleted.
+This includes child resources, if those are not linked to other resources.
 
 .. _shapes:
 
@@ -96,7 +114,9 @@ A typical resource shape contains the following key elements:
 User interface directives
 -------------------------
 
-The `DASH <http://datashapes.org/dash>`_ vocabulary introduces extensions to the core SHACL model. One of the extensions is focused on providing user interface hints for shape properties. Introducing or removing a ``dash:viewer`` or ``dash:editor`` property to a ``sh:PropertyShape`` instance influences how the user interface displays the property value.
+The `DASH <http://datashapes.org/dash>`_ vocabulary introduces extensions to the core SHACL model.
+One of the extensions is focused on providing user interface hints for shape properties.
+Introducing or removing a ``dash:viewer`` or ``dash:editor`` property to a ``sh:PropertyShape`` instance influences how the user interface displays the property value.
 
 .. code :: turtle
 
@@ -107,12 +127,18 @@ The `DASH <http://datashapes.org/dash>`_ vocabulary introduces extensions to the
         dash:editor dash:TextFieldEditor ;
     ]
 
-By adding a ``dash:viewer`` statement, the user interface is instructed to show the property value when the resource metadata is displayed. Removing a ``dash:viewer`` statement will instruct the user interface will not render the property value at all. The value will still be present in the metadata model. The supported set of viewers:
+By adding a ``dash:viewer`` statement, the user interface is instructed to show the property value when the resource metadata is displayed.
+Removing a ``dash:viewer`` statement will instruct the user interface will not render the property value at all.
+The value will still be present in the metadata model.
+The supported set of viewers:
 
 * ``sh:LabelViewer``
 * ``sh:URIViewer``
 
-By adding a ``dash:editor`` statement, the editor form in the user interface will show an edit field for the property. Removing a ``dash:editor`` statement will prevent the property from being edited. This could be intended behaviour for properties that are generated server side. The supported set of editors:
+By adding a ``dash:editor`` statement, the editor form in the user interface will show an edit field for the property.
+Removing a ``dash:editor`` statement will prevent the property from being edited.
+This could be intended behaviour for properties that are generated server side.
+The supported set of editors:
 
 * ``sh:TextFieldEditor``
 * ``sh:TextAreaEditor``
@@ -122,7 +148,8 @@ By adding a ``dash:editor`` statement, the editor form in the user interface wil
 Extending an existing shape
 ---------------------------
 
-Extending an existing shape can be achieved by targeting the same ``sh:targetClass``. For example, to extend the existing ``dcat:Dataset`` shape, an extension shape could look like the following:
+Extending an existing shape can be achieved by targeting the same ``sh:targetClass``.
+For example, to extend the existing ``dcat:Dataset`` shape, an extension shape could look like the following:
 
 .. code :: turtle
 


### PR DESCRIPTION
- convert single-line paragraphs to multi-line paragraphs, where each sentence is on a separate line
- actual text *content* is ***not*** changed
- general cleanup, e.g. whitespace

This improves code readability and improves our ability to track code changes using line diffs.

fixes #80 